### PR TITLE
fix: Memoize CodeBlock

### DIFF
--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -3,9 +3,10 @@ import {
   CopyToClipboard,
   TextContent,
 } from "@cloudscape-design/components";
+import React from "react";
 import Highlight from "react-highlight";
 
-export default function CodeBlock({
+function CodeBlock({
   code,
   language,
   copyEnabled = false,
@@ -35,3 +36,5 @@ export default function CodeBlock({
     </div>
   );
 }
+
+export default React.memo(CodeBlock);


### PR DESCRIPTION
CodeBlock is re-rendering even when props do not change due to parent component re-rendering. CodeBlock render is expensive due to syntax highlighting. This is creating perf issues when a large amount of code is loaded into CodeBlock and repeatedly re-rendering.

Memoize CodeBlock to prevent re-renderings when props do not change.